### PR TITLE
Add upvote/downvote feature for proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Git worktrees
+.worktrees

--- a/src/common/components/cards/ProposalEntry.jsx
+++ b/src/common/components/cards/ProposalEntry.jsx
@@ -1,3 +1,4 @@
+import VoteButtons from '@/common/components/votes/VoteButtons';
 import styled from 'styled-components';
 
 const CardContainer = styled.div`
@@ -103,7 +104,10 @@ export default function ProposalEntry({
   description,
   date,
   votes,
+  userVote,
+  onVote,
   onCommentClick,
+  disabled = false,
 }) {
   return (
     <CardContainer>
@@ -114,7 +118,7 @@ export default function ProposalEntry({
             <Title>{title}</Title>
             <CategoryBadge>{category}</CategoryBadge>
           </TitleGroup>
-          <VoteCount>{votes} Votes</VoteCount>
+          <VoteButtons votes={votes} userVote={userVote} onVote={onVote} disabled={disabled} />
         </HeaderRow>
 
         <Description>{description}</Description>

--- a/src/common/components/votes/VoteButtons.jsx
+++ b/src/common/components/votes/VoteButtons.jsx
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+`;
+
+const VoteButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${(props) => {
+    if (props.$active === 'up') return '#22c55e';
+    if (props.$active === 'down') return '#ef4444';
+    return '#9ca3af';
+  }};
+  transition: transform 0.1s ease, color 0.15s ease;
+
+  &:hover {
+    transform: scale(1.15);
+    color: ${(props) => {
+      if (props.$active === 'up') return '#16a34a';
+      if (props.$active === 'down') return '#dc2626';
+      return '#6b7280';
+    }};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    transform: none;
+  }
+`;
+
+const ArrowIcon = styled.svg`
+  width: 18px;
+  height: 18px;
+`;
+
+const Count = styled.span`
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #4d4d4d;
+  min-width: 2rem;
+  text-align: center;
+`;
+
+const UpArrow = () => (
+  <ArrowIcon viewBox='0 0 24 24' fill='currentColor'>
+    <path d='M12 4l-8 8h5v8h6v-8h5z' />
+  </ArrowIcon>
+);
+
+const DownArrow = () => (
+  <ArrowIcon viewBox='0 0 24 24' fill='currentColor'>
+    <path d='M12 20l8-8h-5v-8h-6v8h-5z' />
+  </ArrowIcon>
+);
+
+export default function VoteButtons({ votes, userVote, onVote, disabled = false }) {
+  const handleUpvote = () => onVote(userVote === 'up' ? null : 'up');
+  const handleDownvote = () => onVote(userVote === 'down' ? null : 'down');
+
+  return (
+    <Container>
+      <VoteButton
+        $active={userVote === 'up' ? 'up' : null}
+        onClick={handleUpvote}
+        disabled={disabled}
+        aria-label='Upvote'
+      >
+        <UpArrow />
+      </VoteButton>
+      <Count>{votes}</Count>
+      <VoteButton
+        $active={userVote === 'down' ? 'down' : null}
+        onClick={handleDownvote}
+        disabled={disabled}
+        aria-label='Downvote'
+      >
+        <DownArrow />
+      </VoteButton>
+    </Container>
+  );
+}

--- a/src/pages/browse/BrowseIdeas.jsx
+++ b/src/pages/browse/BrowseIdeas.jsx
@@ -142,15 +142,16 @@ const formatDate = (value) =>
     year: 'numeric',
   });
 
-async function fetchApi(path) {
+async function fetchApi(path, options = {}) {
   const token = await auth.currentUser?.getIdToken?.();
-  const headers = {};
+  const headers = { ...options.headers };
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
 
   const response = await fetch(buildApiUrl(path), {
     credentials: 'include',
+    ...options,
     headers,
   });
 
@@ -204,6 +205,8 @@ export default function BrowseIdeas() {
   const [modalLoading, setModalLoading] = useState(false);
   const [modalError, setModalError] = useState('');
   const [selectedProposal, setSelectedProposal] = useState(null);
+
+  const [votingProposals, setVotingProposals] = useState(new Set());
 
   const queryString = useMemo(
     () => buildQueryString({ search, category, status, sort, tag: activeTag }),
@@ -328,6 +331,76 @@ export default function BrowseIdeas() {
     }
   };
 
+  const handleVote = async (proposalId, voteType) => {
+    if (!auth.currentUser) {
+      alert('Please log in to vote on proposals.');
+      return;
+    }
+
+    setVotingProposals((prev) => new Set(prev).add(proposalId));
+
+    const previousProposals = [...proposals];
+    const proposal = proposals.find((p) => p.id === proposalId);
+    if (!proposal) return;
+
+    const previousVote = proposal.userVote;
+    const previousVotes = proposal.votes;
+
+    const optimisticUpdate = (currentVote, currentVotes) => {
+      if (currentVote === voteType) {
+        return { newVote: null, voteChange: -1 };
+      }
+      if (currentVote === 'up' && voteType === 'down') {
+        return { newVote: 'down', voteChange: -2 };
+      }
+      if (currentVote === 'down' && voteType === 'up') {
+        return { newVote: 'up', voteChange: 2 };
+      }
+      if (voteType === 'up') {
+        return { newVote: 'up', voteChange: 1 };
+      }
+      if (voteType === 'down') {
+        return { newVote: 'down', voteChange: -1 };
+      }
+      return { newVote: null, voteChange: 0 };
+    };
+
+    const { newVote, voteChange } = optimisticUpdate(previousVote, previousVotes);
+
+    setProposals((prev) =>
+      prev.map((p) =>
+        p.id === proposalId
+          ? { ...p, votes: p.votes + voteChange, userVote: newVote }
+          : p
+      )
+    );
+
+    try {
+      const result = await fetchApi(`/proposals/${proposalId}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vote_type: voteType }),
+      });
+
+      setProposals((prev) =>
+        prev.map((p) =>
+          p.id === proposalId
+            ? { ...p, votes: result.votes, userVote: result.userVote }
+            : p
+        )
+      );
+    } catch (voteError) {
+      setProposals(previousProposals);
+      alert(voteError.message || 'Failed to record vote. Please try again.');
+    } finally {
+      setVotingProposals((prev) => {
+        const next = new Set(prev);
+        next.delete(proposalId);
+        return next;
+      });
+    }
+  };
+
   return (
     <PageContainer>
       <PageHeader>
@@ -422,7 +495,10 @@ export default function BrowseIdeas() {
                   description={proposal.description}
                   date={formatDate(proposal.submittedAt)}
                   votes={proposal.votes}
+                  userVote={proposal.userVote}
+                  onVote={(voteType) => handleVote(proposal.id, voteType)}
                   onCommentClick={() => openProposalDetails(proposal.id)}
+                  disabled={votingProposals.has(proposal.id)}
                 />
               ))
             : null}


### PR DESCRIPTION
## Summary
- Add `VoteButtons` component with up/down arrow UI
- Update `ProposalEntry` to render the interactive vote buttons
- Update `BrowseIdeas` with vote handlers and optimistic state updates
- Show login prompt for anonymous users when they try to vote
- Add `.worktrees/` to `.gitignore`

Wires to backend on `disc-be` branch `feature/proposal-voting` (commit 8549056) which adds `proposal_votes` table and `POST/GET/DELETE /proposals/:id/vote` endpoints.

Split out from #30.

## Test plan
- [ ] Browse ideas page renders vote buttons on each proposal
- [ ] Logged-in user can upvote/downvote and counts update optimistically
- [ ] Anonymous user is prompted to log in when voting
- [ ] No regressions on the proposal card layout