### PR TITLE
Show submission success popup and redirect to home

### DIFF
--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useContext, useEffect, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 // 1. IMPORT YOUR COMPONENTS & ASSETS
 import heroBg from '@/assets/hero-bg.jpg';
@@ -143,14 +143,88 @@ const Divider = styled.div`
   opacity: 0.2;
 `;
 
+const ToastContainer = styled.div`
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  z-index: 1100;
+  pointer-events: none;
+`;
+
+const Toast = styled.div`
+  width: min(360px, calc(100vw - 2.5rem));
+  max-width: 360px;
+  background-color: #ffffff;
+  border: 1px solid #e2b853;
+  border-left: 6px solid #e2b853;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.16);
+  padding: 0.9rem 1rem;
+  pointer-events: auto;
+`;
+
+const ToastTitle = styled.p`
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f1f1f;
+`;
+
+const ToastBody = styled.p`
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  color: #4d4d4d;
+`;
+
 // --- MAIN COMPONENT RENDER ---
 
 export default function Home() {
   const context = useContext(UserContext);
   const isAdmin = context?.user?.role === 'admin';
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [showSubmissionToast, setShowSubmissionToast] = useState(false);
+
+  useEffect(() => {
+    if (!location.state?.submissionSuccessToast) {
+      return undefined;
+    }
+
+    setShowSubmissionToast(true);
+
+    const dismissTimer = setTimeout(() => {
+      setShowSubmissionToast(false);
+    }, 3200);
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash,
+      },
+      {
+        replace: true,
+        state: null,
+      }
+    );
+
+    return () => clearTimeout(dismissTimer);
+  }, [location.hash, location.pathname, location.search, location.state, navigate]);
 
   return (
     <div>
+      {showSubmissionToast ? (
+        <ToastContainer aria-live='polite'>
+          <Toast role='status'>
+            <ToastTitle>Proposal submitted</ToastTitle>
+            <ToastBody>
+              Thanks for sharing your idea. The team will review it shortly.
+            </ToastBody>
+          </Toast>
+        </ToastContainer>
+      ) : null}
+
       {/* HERO SECTION */}
       <HeroContainer>
         <TopSubtitle>For our local community, Evanston</TopSubtitle>

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -193,10 +193,6 @@ export default function Home() {
 
     setShowSubmissionToast(true);
 
-    const dismissTimer = setTimeout(() => {
-      setShowSubmissionToast(false);
-    }, 3200);
-
     navigate(
       {
         pathname: location.pathname,
@@ -208,9 +204,19 @@ export default function Home() {
         state: null,
       }
     );
+  }, [location.hash, location.pathname, location.search, location.state, navigate]);
+
+  useEffect(() => {
+    if (!showSubmissionToast) {
+      return undefined;
+    }
+
+    const dismissTimer = setTimeout(() => {
+      setShowSubmissionToast(false);
+    }, 3200);
 
     return () => clearTimeout(dismissTimer);
-  }, [location.hash, location.pathname, location.search, location.state, navigate]);
+  }, [showSubmissionToast]);
 
   return (
     <div>

--- a/src/pages/submit/SubmissionForm.jsx
+++ b/src/pages/submit/SubmissionForm.jsx
@@ -166,61 +166,6 @@ const ErrorText = styled.p`
   text-align: center;
 `;
 
-const ModalOverlay = styled.div`
-  position: fixed;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1rem;
-`;
-
-const ModalCard = styled.div`
-  width: 100%;
-  max-width: 520px;
-  background-color: #ffffff;
-  border-radius: 20px;
-  border: 1px solid #e2e2e2;
-  padding: 2rem;
-  text-align: center;
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
-`;
-
-const ModalTitle = styled.h2`
-  margin: 0 0 0.75rem;
-  font-size: 1.6rem;
-`;
-
-const ModalMessage = styled.p`
-  margin: 0;
-  color: #4f4f4f;
-  line-height: 1.5;
-`;
-
-const ModalActions = styled.div`
-  margin-top: 1.75rem;
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-
-  @media (max-width: 520px) {
-    flex-direction: column;
-  }
-`;
-
-const ModalActionButton = styled.button`
-  border: 1px solid #d2d2d2;
-  background-color: ${(props) => (props.$primary ? '#e2b853' : '#ffffff')};
-  color: #1f1f1f;
-  border-radius: 12px;
-  padding: 0.8rem 1.2rem;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-`;
-
 // --- COMPONENT RENDER ---
 
 export default function SubmissionForm() {
@@ -236,7 +181,6 @@ export default function SubmissionForm() {
   });
 
   const [errors, setErrors] = useState({});
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   //const[isSubmitting, setIsSubmitting] = useState(false);
 
   function handleChange(event) {
@@ -288,7 +232,6 @@ export default function SubmissionForm() {
 
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
-      setIsSuccessModalOpen(false);
       return;
     }
 
@@ -342,7 +285,10 @@ export default function SubmissionForm() {
       console.log('Successfully saved to backend:', result);
 
       setErrors({});
-      setIsSuccessModalOpen(true);
+      navigate('/', {
+        replace: true,
+        state: { submissionSuccessToast: true },
+      });
     } catch (error) {
       console.error('Submission error:', error);
       // #region agent log
@@ -366,7 +312,6 @@ export default function SubmissionForm() {
       setErrors({
         submit: error.message || 'An error occurred while submitting.',
       });
-      setIsSuccessModalOpen(false);
     }
   }
 
@@ -506,46 +451,6 @@ export default function SubmissionForm() {
         </div>
         {errors.submit ? <ErrorText>{errors.submit}</ErrorText> : null}
       </FormContainer>
-
-      {isSuccessModalOpen ? (
-        <ModalOverlay
-          onClick={() => setIsSuccessModalOpen(false)}
-          role='presentation'
-        >
-          <ModalCard
-            role='dialog'
-            aria-modal='true'
-            aria-labelledby='submission-success-title'
-            onClick={(event) => event.stopPropagation()}
-          >
-            <ModalTitle id='submission-success-title'>
-              Proposal Submitted
-            </ModalTitle>
-            <ModalMessage>
-              Your proposal was submitted successfully and will be reviewed by
-              the team.
-            </ModalMessage>
-            <ModalActions>
-              <ModalActionButton
-                $primary
-                type='button'
-                onClick={() => {
-                  setIsSuccessModalOpen(false);
-                  navigate('/');
-                }}
-              >
-                Return to Homepage
-              </ModalActionButton>
-              <ModalActionButton
-                type='button'
-                onClick={() => setIsSuccessModalOpen(false)}
-              >
-                Stay on This Page
-              </ModalActionButton>
-            </ModalActions>
-          </ModalCard>
-        </ModalOverlay>
-      ) : null}
     </PageWrapper>
   );
 }

--- a/src/pages/submit/SubmissionForm.jsx
+++ b/src/pages/submit/SubmissionForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import ProposalSubmitButton from '@/common/components/buttons/ProposalSubmitButton';
 import styled from 'styled-components';
@@ -158,9 +159,73 @@ const PrivacyNotice = styled.div`
   line-height: 1.5;
 `;
 
+const ErrorText = styled.p`
+  margin-top: 1rem;
+  color: #b53737;
+  font-weight: 600;
+  text-align: center;
+`;
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+`;
+
+const ModalCard = styled.div`
+  width: 100%;
+  max-width: 520px;
+  background-color: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #e2e2e2;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+`;
+
+const ModalTitle = styled.h2`
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+`;
+
+const ModalMessage = styled.p`
+  margin: 0;
+  color: #4f4f4f;
+  line-height: 1.5;
+`;
+
+const ModalActions = styled.div`
+  margin-top: 1.75rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+
+  @media (max-width: 520px) {
+    flex-direction: column;
+  }
+`;
+
+const ModalActionButton = styled.button`
+  border: 1px solid #d2d2d2;
+  background-color: ${(props) => (props.$primary ? '#e2b853' : '#ffffff')};
+  color: #1f1f1f;
+  border-radius: 12px;
+  padding: 0.8rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
 // --- COMPONENT RENDER ---
 
 export default function SubmissionForm() {
+  const navigate = useNavigate();
+
   // state for relation toggles
   const [formData, setFormData] = useState({
     category: '',
@@ -171,7 +236,7 @@ export default function SubmissionForm() {
   });
 
   const [errors, setErrors] = useState({});
-  const [success, setSuccess] = useState('');
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   //const[isSubmitting, setIsSubmitting] = useState(false);
 
   function handleChange(event) {
@@ -223,7 +288,7 @@ export default function SubmissionForm() {
 
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
-      setSuccess('');
+      setIsSuccessModalOpen(false);
       return;
     }
 
@@ -269,15 +334,15 @@ export default function SubmissionForm() {
       // #endregion
 
       if (!response.ok) {
-        const errorData = await response.json();
+        const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.error || 'Failed to submit proposal');
       }
 
       const result = await response.json();
       console.log('Successfully saved to backend:', result);
 
-      setSuccess('Proposal submitted successfully!');
       setErrors({});
+      setIsSuccessModalOpen(true);
     } catch (error) {
       console.error('Submission error:', error);
       // #region agent log
@@ -301,7 +366,7 @@ export default function SubmissionForm() {
       setErrors({
         submit: error.message || 'An error occurred while submitting.',
       });
-      setSuccess('');
+      setIsSuccessModalOpen(false);
     }
   }
 
@@ -439,8 +504,48 @@ export default function SubmissionForm() {
             Submit Proposal
           </ProposalSubmitButton>
         </div>
-        {success && <p>{success}</p>}
+        {errors.submit ? <ErrorText>{errors.submit}</ErrorText> : null}
       </FormContainer>
+
+      {isSuccessModalOpen ? (
+        <ModalOverlay
+          onClick={() => setIsSuccessModalOpen(false)}
+          role='presentation'
+        >
+          <ModalCard
+            role='dialog'
+            aria-modal='true'
+            aria-labelledby='submission-success-title'
+            onClick={(event) => event.stopPropagation()}
+          >
+            <ModalTitle id='submission-success-title'>
+              Proposal Submitted
+            </ModalTitle>
+            <ModalMessage>
+              Your proposal was submitted successfully and will be reviewed by
+              the team.
+            </ModalMessage>
+            <ModalActions>
+              <ModalActionButton
+                $primary
+                type='button'
+                onClick={() => {
+                  setIsSuccessModalOpen(false);
+                  navigate('/');
+                }}
+              >
+                Return to Homepage
+              </ModalActionButton>
+              <ModalActionButton
+                type='button'
+                onClick={() => setIsSuccessModalOpen(false)}
+              >
+                Stay on This Page
+              </ModalActionButton>
+            </ModalActions>
+          </ModalCard>
+        </ModalOverlay>
+      ) : null}
     </PageWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- Replace text-only confirmation in `SubmissionForm` with a redirect to the home page on successful submission
- Show a non-blocking success toast on the home page after submission
- Toast auto-dismisses after ~3.2s and clears the navigation state so it doesn't reappear on reload

Split out from #30. Supersedes #17.

## Test plan
- [ ] Submitting a valid proposal navigates back to `/` and shows the success toast
- [ ] Toast auto-dismisses and does not reappear on refresh
- [ ] Validation errors still display inline and do not redirect
- [ ] Submission API errors surface inline error text on the form